### PR TITLE
Keep the original payload

### DIFF
--- a/vicephp/Virtue-JWT/tests/JWT/TokenTest.php
+++ b/vicephp/Virtue-JWT/tests/JWT/TokenTest.php
@@ -31,4 +31,10 @@ class TokenTest extends TestCase
         $token->verifyWith($hmac256);
         $this->assertNotEmpty($token->signature());
     }
+
+    public function testPayloadIsPreserved()
+    {
+        $token = Token::ofString('eyJraWQiOiJraWQtMSIsInR5cCI6IkpXVCIsImFsZyI6IkhTMjU2In0.e30.q8fjb85nnNWUoeW4NNXuwWKvFYJ4sjMCA1XJvdOCcsg');
+        $this->assertEquals('eyJraWQiOiJraWQtMSIsInR5cCI6IkpXVCIsImFsZyI6IkhTMjU2In0.e30', $token->withoutSig());
+    }
 }


### PR DESCRIPTION
In some cases `json_encode` might change the order of keys in the resulting string (as per JSON standard the order of keys is not guaranteed). In this case the token would be different and result in a different signature. We have to keep the original payload in these cases.