### PR TITLE
Remove trailing slash from the issuer

### DIFF
--- a/vicephp/Virtue-JWT/src/JWK/Store/OpenIdKeyStore.php
+++ b/vicephp/Virtue-JWT/src/JWK/Store/OpenIdKeyStore.php
@@ -18,7 +18,7 @@ class OpenIdKeyStore implements KeyStore
 
     public function getFor(Token $token): KeySet
     {
-        $response = $this->client->get($token->payload('iss') . '/.well-known/openid-configuration');
+        $response = $this->client->get(rtrim($token->payload('iss'), '/') . '/.well-known/openid-configuration');
         $config = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
 
         if (!filter_var($config['jwks_uri'] ?? '', FILTER_VALIDATE_URL)) {

--- a/vicephp/Virtue-JWT/tests/JWK/Store/OpenIdKeyStoreTest.php
+++ b/vicephp/Virtue-JWT/tests/JWK/Store/OpenIdKeyStoreTest.php
@@ -12,6 +12,24 @@ class OpenIdKeyStoreTest extends TestCase
 {
     use M\Adapter\Phpunit\MockeryPHPUnitIntegration;
 
+    public function testRemoveTrailingSlashFromIssuer()
+    {
+        $token = new Token([], ['iss' => 'https://issuer.ggs-ps.com/']);
+
+        $response = new Response(200, [], json_encode(['jwks_uri' => 'https://issuer.ggs-ps.com/keys']));
+        $client = M::mock(Client::class);
+        $client->shouldReceive('get')
+            ->with('https://issuer.ggs-ps.com/.well-known/openid-configuration')
+            ->andReturn($response)
+            ->once();
+
+        $response = new Response(200, [], json_encode(['keys' => [[]]]));
+        $client->shouldReceive('get')->andReturn($response)->once();
+
+        $store = new OpenIdKeyStore($client);
+        $store->getFor($token);
+    }
+
     public function testGetKeySet()
     {
         $token = new Token([], ['iss' => 'https://issuer.ggs-ps.com']);


### PR DESCRIPTION
Remove trailing slash from the issuer to ensure having a valid URL for the OpenId configuration