### PR TITLE
Support multiple audiences per token

### DIFF
--- a/vicephp/Virtue-JWT/src/JWT/Algorithms/ClaimsVerify.php
+++ b/vicephp/Virtue-JWT/src/JWT/Algorithms/ClaimsVerify.php
@@ -37,6 +37,7 @@ class ClaimsVerify implements VerifiesToken
 
         $issuer = $token->payload('iss');
         $audience = $token->payload('aud');
+        $audience = is_string($audience) ? [$audience] : $audience;
         $subject = $token->payload('sub');
 
         if ($now > $exp + $leeway) {
@@ -60,7 +61,7 @@ class ClaimsVerify implements VerifiesToken
             throw new VerificationFailed('Issuer is not allowed');
         }
 
-        if (isset($this->settings['audience']) && $audience !== $this->settings['audience']) {
+        if (isset($this->settings['audience']) && !in_array($this->settings['audience'], $audience)) {
             throw new VerificationFailed('Audience is not allowed');
         }
 


### PR DESCRIPTION
[4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3).  "aud" (Audience) Claim

   The "aud" (audience) claim identifies the recipients that the JWT is
   intended for.  Each principal intended to process the JWT MUST
   identify itself with a value in the audience claim.  If the principal
   processing the claim does not identify itself with a value in the
   "aud" claim when this claim is present, then the JWT MUST be
   rejected.  In the general case, the "aud" value is an array of case-
   sensitive strings, each containing a StringOrURI value.  In the
   special case when the JWT has one audience, the "aud" value MAY be a
   single case-sensitive string containing a StringOrURI value.  The
   interpretation of audience values is generally application specific.
   Use of this claim is OPTIONAL.