### PR TITLE
Check if .well-known openId configs response contains valid data

### DIFF
--- a/vicephp/Virtue-JWT/src/JWK/Store/OpenIdKeyStore.php
+++ b/vicephp/Virtue-JWT/src/JWK/Store/OpenIdKeyStore.php
@@ -24,9 +24,14 @@ class OpenIdKeyStore implements KeyStore
     {
         $issuer = $token->payload('iss');
         Assert::string($issuer, 'Issuer must be a string');
+
         $response = $this->client->request('GET', rtrim($issuer, '/') . '/.well-known/openid-configuration');
-        $config = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
-        Assert::isArray($config, 'Invalid OpenID configuration');
+        Assert::eq($response->getStatusCode(), 200, 'Failed to fetch OpenID configuration');
+
+        $config = json_decode((string) $response->getBody(), true, 512);
+        Assert::eq(json_last_error(), JSON_ERROR_NONE, 'Invalid OpenID configuration: It must be a valid JSON string');
+        Assert::isArray($config, 'Invalid OpenID configuration: It must be an array');
+
         if ($this->strict) {
             Assert::keyExists($config, 'iss', 'Invalid OpenID configuration');
             Assert::eq($config['iss'], $issuer, 'iss claim does not match configured issuer');

--- a/vicephp/Virtue-JWT/tests/JWK/Store/OpenIdKeyStoreTest.php
+++ b/vicephp/Virtue-JWT/tests/JWK/Store/OpenIdKeyStoreTest.php
@@ -13,6 +13,43 @@ class OpenIdKeyStoreTest extends TestCase
 {
     use M\Adapter\Phpunit\MockeryPHPUnitIntegration;
 
+    /**
+     * @dataProvider invalidOpenIdConfigResponse
+     */
+    public function testInvalidOpenIdConfiguration(
+        Response $openIdConfigResponse,
+        string $expectedException,
+        string $expectedExceptionMessage
+    ): void {
+        $this->expectException($expectedException);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
+        $client = M::mock(ClientInterface::class);
+        $client->shouldReceive('request')
+            ->with('GET', 'https://issuer.ggs-ps.com/.well-known/openid-configuration')
+            ->andReturn($openIdConfigResponse)
+            ->once();
+
+        $token = new Token([], ['iss' => 'https://issuer.ggs-ps.com/']);
+
+        (new OpenIdKeyStore($client))->getFor($token);
+    }
+
+    public function invalidOpenIdConfigResponse(): \Generator
+    {
+        yield 'not 200 response' => [
+            new Response(500),
+            \InvalidArgumentException::class,
+            'Failed to fetch OpenID configuration',
+        ];
+
+        yield '200 response with invalid content' => [
+            new Response(200, [], Psr7\Utils::streamFor('asd-fgh')),
+            \InvalidArgumentException::class,
+            'Invalid OpenID configuration: It must be a valid JSON string',
+        ];
+    }
+
     public function testRemoveTrailingSlashFromIssuer(): void
     {
         $token = new Token([], ['iss' => 'https://issuer.ggs-ps.com/']);


### PR DESCRIPTION
Add extra checks on the retrieved openId configs